### PR TITLE
initial support for sms

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [com.google.firebase/firebase-admin "6.2.0"]
                  [environ "1.1.0"]
                  [aleph "0.4.6"]
-                 [jstrutz/hashids "1.0.1"]]
+                 [jstrutz/hashids "1.0.1"]
+                 [com.twilio.sdk "7.17.0"]]
   :min-lein-version "2.8.0"
   :main kareem.core)

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
                  [com.google.firebase/firebase-admin "6.2.0"]
                  [environ "1.1.0"]
                  [aleph "0.4.6"]
-                 [jstrutz/hashids "1.0.1"]
-                 [com.twilio.sdk "7.17.0"]]
+                 [jstrutz/hashids "1.0.1"]]
   :min-lein-version "2.8.0"
   :main kareem.core)

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -97,6 +97,7 @@
                    .build)
         get-req (HttpGet. (.toURI (URL. uri)))
         res (.execute client get-req)]
+    ;; TODO(stopachka) really understand with-open -- why is it needed here
     (with-open [in (-> res
                        .getEntity
                        .getContent)

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -289,6 +289,7 @@
         atts (->atts params)]
     {:sender {:id (parse-int from)
               :from from}
+     :timestamp (System/currentTimeMillis)
      :message {:text text
                :attachments atts}}))
 

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -314,7 +314,7 @@
       (do
         ;; TODO(stopachka)
         ;; What happens if this blocks for too long or fails?
-        ;; i.e maybe we should have timeouts / failure handling
+        ;; i.e maybe we should haveP timeouts / overall try catch
         (save-message! (update-attachments! evt))
         (text-res (get-random-emoji)))
 

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -316,7 +316,7 @@
       (do
         ;; TODO(stopachka)
         ;; What happens if this blocks for too long or fails?
-        ;; i.e maybe we should haveP timeouts / overall try catch
+        ;; maybe we should have timeouts / overall try catch
         (save-message! (update-attachments! evt))
         (text-res (get-random-emoji)))
 

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -308,7 +308,7 @@
   (let [text-res #(xml-response (text-twiml %))
         {:keys [sender message] :as evt} (->message params)
         intent (parse-intent message)]
-    (condp = intent
+    (case intent
       ::history
       (text-res (history-uri sender))
 

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -275,7 +275,8 @@
                        url-k (keyword (str "MediaUrl" i))
                        content-type (content-type-k params)]
                    ;; TODO(stopachka)
-                   ;; remove "type", to support more then images
+                   ;; remove "type", and use content-type in the ui
+                   ;; this will allow us to be more specific about extensions
                    (when (= content-type "image/jpeg")
                      {:type "image"
                       :content-type content-type
@@ -303,7 +304,7 @@
 
 (defn post-sms [{:keys [params]}]
   (let [text-res #(xml-response (text-twiml %))
-        {:keys [sender message] :as evt} (-> params ->message)
+        {:keys [sender message] :as evt} (->message params)
         intent (parse-intent message)]
     (condp = intent
       ::history
@@ -317,7 +318,7 @@
         (save-message! (update-attachments! evt))
         (text-res (get-random-emoji)))
 
-      (text-res "An unexpected error occured. Contact Stepan"))))
+      (text-res "An unexpected error occured. Give us a ping :}"))))
 
 (defroutes routes
            (GET "/ping" [] pong)

--- a/src/kareem/core.clj
+++ b/src/kareem/core.clj
@@ -10,8 +10,7 @@
             [clojure.java.io :as io]
             [environ.core :refer [env]]
             [aleph.http :as http]
-            [hashids.core :as hashids]
-            [clojure.string :as str])
+            [hashids.core :as hashids])
   (:import (java.lang Long)
            (com.google.firebase FirebaseApp)
            (com.google.firebase FirebaseOptions$Builder)
@@ -260,16 +259,16 @@
   (let [num-media (parse-int (:NumMedia params))]
     (->> num-media
          range
-         (map (fn [i]
-                (let [content-type-k (keyword (str "MediaContentType" i))
-                      url-k (keyword (str "MediaUrl" i))
-                      content-type (content-type-k params)]
-                  ;; TODO(stopachka)
-                  ;; remove "type", to support more then images
-                  (when (= content-type "image/jpeg")
-                    {:type "image"
-                     :content-type content-type
-                     :payload {:url (url-k params)}})))))))
+         (keep (fn [i]
+                 (let [content-type-k (keyword (str "MediaContentType" i))
+                       url-k (keyword (str "MediaUrl" i))
+                       content-type (content-type-k params)]
+                   ;; TODO(stopachka)
+                   ;; remove "type", to support more then images
+                   (when (= content-type "image/jpeg")
+                     {:type "image"
+                      :content-type content-type
+                      :payload {:url (url-k params)}})))))))
 
 (defn ->message [params]
   (let [text (:Body params)


### PR DESCRIPTION
A bit hacky, but this about 80% adds initial support for sms (slight updates will come next free hour I have)

Current features
- supports "history"
- supports messages + attachements

Still need to test:
- how all of this will render

**Follow-ups**
- we currently use the phone number as id
  - this is insecure, for if a users knows someone's phone number, and somehow gets access to the salt, they could get the hash
    - we could use something more unique
- we currently only support images
  - messenger had a "type" field. twilio gives us the full content-type. it's better to use content-type, since I don't know if twilio guarantees everything will be jpg or mp4, like messenger does
- we still have the messenger code lying around
  - in a follow-on diff, will just delete it -- f the biz verification >:) 
- we currently use strings to create twiml
  - twilio has an sdk we can use -- may add this later, but just for sending text back, building up a string seems fine to me
- we do not compress images
  - twilio seems to send pretty high quality images -- this may cause history load times to slow
- we don't have a good async strategy
  - we currently block when making async requests -- would be good to not do that -- either using futures or go-routines. 
  - we also may be failing gracelessly -- i wonder what would happen if > 8 requests hit in parallel and got the threads stuck
- ui is in a different repo
  - thinking about this, i.m.o let's have all in one repo -- will make dev faster